### PR TITLE
Fix last attendee alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -108,6 +108,11 @@ th {
 	padding: 0;
 }
 
+.tix-attendee-list::after {
+	content: "";
+	flex: auto;
+}
+
 #tix .tix-ticket-form + p {
 	display: none;
 }


### PR DESCRIPTION
When the last row of the attendees list is not filled with three attendees, but only with two, the last one is aligned right and not centered. This can easily be fixed with this simple addition.